### PR TITLE
Remove version check and invalid file.Find

### DIFF
--- a/lua/autorun/server/ctp.lua
+++ b/lua/autorun/server/ctp.lua
@@ -39,31 +39,18 @@ if game.SinglePlayer() then
 else
 	AddCSLuaFile("autorun/client/ctp.lua")
 
-	if VERSION >= 150 then
-		for key, value in pairs(file.Find("ctp/cvar_presets/*", "DATA")) do
-			resource.AddFile("data/ctp/cvar_presets/" .. value)
-		end
-
-		for key, value in pairs(file.Find("ctp/default_cvar_presets/*", "DATA")) do
-			resource.AddFile("data/ctp/default_cvar_presets/" .. value)
-		end
-
-		for key, value in pairs(file.Find("ctp/node_presets/*", "DATA")) do
-			resource.AddFile("data/ctp/node_presets/" .. value)
-		end
-	else
-		for key, value in pairs(file.Find("ctp/cvar_presets/*")) do
-			resource.AddFile("data/ctp/cvar_presets/" .. value)
-		end
-
-		for key, value in pairs(file.Find("ctp/default_cvar_presets/*")) do
-			resource.AddFile("data/ctp/default_cvar_presets/" .. value)
-		end
-
-		for key, value in pairs(file.Find("ctp/node_presets/*")) do
-			resource.AddFile("data/ctp/node_presets/" .. value)
-		end
+	for key, value in pairs(file.Find("ctp/cvar_presets/*", "DATA")) do
+		resource.AddFile("data/ctp/cvar_presets/" .. value)
 	end
+
+	for key, value in pairs(file.Find("ctp/default_cvar_presets/*", "DATA")) do
+		resource.AddFile("data/ctp/default_cvar_presets/" .. value)
+	end
+
+	for key, value in pairs(file.Find("ctp/node_presets/*", "DATA")) do
+		resource.AddFile("data/ctp/node_presets/" .. value)
+	end
+
 end
 
 local META = FindMetaTable("Player")


### PR DESCRIPTION
See: http://wiki.garrysmod.com/page/file/Find

`file.Find` requires the 2nd parameter (path, e.g., "DATA", "LUA", etc) to be supplied and does not have a default value. The original code never caused errors unless the server was running on the dev branch, in which case the version would be less than 150 (currently 14).

The version check and invalid file.Finds should simply be removed so that CTP works on both main and dev branches.
